### PR TITLE
Unescape escaped newlines

### DIFF
--- a/.github/workflows/qaa_slack_bot.yml
+++ b/.github/workflows/qaa_slack_bot.yml
@@ -24,4 +24,5 @@ jobs:
           run_status: "passed"
           bluescape_url: "stg1.bluescape.com"
           testrail_project_id: "15"
-          extra_text: "hello\\nthis\\nis\\*a test*\\n and an example"
+          extra_text: "*Done Issues Tagged Against Tests:*\nlinkone\nlinktwo"
+          

--- a/.github/workflows/qaa_slack_bot.yml
+++ b/.github/workflows/qaa_slack_bot.yml
@@ -24,3 +24,4 @@ jobs:
           run_status: "passed"
           bluescape_url: "stg1.bluescape.com"
           testrail_project_id: "15"
+          extra_text: "*Done Issues Tagged Against Tests:* \nhttps://jira.common.bluescape.com/browse/WEBC-9057"

--- a/.github/workflows/qaa_slack_bot.yml
+++ b/.github/workflows/qaa_slack_bot.yml
@@ -24,4 +24,4 @@ jobs:
           run_status: "passed"
           bluescape_url: "stg1.bluescape.com"
           testrail_project_id: "15"
-          extra_text: hello\\nthis\\nis\\*a test*\\n and an example
+          extra_text: "hello\\nthis\\nis\\*a test*\\n and an example"

--- a/.github/workflows/qaa_slack_bot.yml
+++ b/.github/workflows/qaa_slack_bot.yml
@@ -31,4 +31,7 @@ jobs:
           run_status: "passed"
           bluescape_url: "stg1.bluescape.com"
           testrail_project_id: "15"
-          extra_text:  ${{ steps.testing.outputs.text }}
+          extra_text:  |
+          *Done Issues Tagged Against Tests:*
+          somelinkgoesheresomeotherlinkgoeshere
+          somethirdlink goes here"

--- a/.github/workflows/qaa_slack_bot.yml
+++ b/.github/workflows/qaa_slack_bot.yml
@@ -24,4 +24,4 @@ jobs:
           run_status: "passed"
           bluescape_url: "stg1.bluescape.com"
           testrail_project_id: "15"
-          extra_text: "*Done Issues Tagged Against Tests:* \nhttps://jira.common.bluescape.com/browse/WEBC-9057"
+          extra_text: "*Done Issues Tagged Against Tests:*\\nhttps://jira.common.bluescape.com/browse/WEBC-9057"

--- a/.github/workflows/qaa_slack_bot.yml
+++ b/.github/workflows/qaa_slack_bot.yml
@@ -24,4 +24,4 @@ jobs:
           run_status: "passed"
           bluescape_url: "stg1.bluescape.com"
           testrail_project_id: "15"
-          extra_text: "*Done Issues Tagged Against Tests:*\\nhttps://jira.common.bluescape.com/browse/WEBC-9057"
+          extra_text: "*Done Issues Tagged Against Tests:*\\nsomelinkgoeshere\nsomeotherlinkgoeshere\\nsomethirdlink goes here"

--- a/.github/workflows/qaa_slack_bot.yml
+++ b/.github/workflows/qaa_slack_bot.yml
@@ -7,8 +7,6 @@ env:
 jobs: 
   post-to-slack:
     runs-on: ubuntu-latest
-    outputs: 
-      tags: ${{steps.testing.outputs.text}}
     steps: 
       - name: Dump Github context
         env: 
@@ -19,11 +17,6 @@ jobs:
         uses: actions/setup-node@v1
         with: 
           node-version: '12.x'
-      - name: Testing variable
-        id: testing 
-        run: |
-          AUDIT=$(node ./src/test.js)
-          echo "::set-output name=text::$AUDIT"
       - name: Run script 
         uses: ./
         with: 
@@ -31,4 +24,4 @@ jobs:
           run_status: "passed"
           bluescape_url: "stg1.bluescape.com"
           testrail_project_id: "15"
-          extra_text:  ${{ steps.testing.outputs.text }}
+          extra_text: hello\\nthis\\nis\\*a test*\\n and an example

--- a/.github/workflows/qaa_slack_bot.yml
+++ b/.github/workflows/qaa_slack_bot.yml
@@ -31,7 +31,4 @@ jobs:
           run_status: "passed"
           bluescape_url: "stg1.bluescape.com"
           testrail_project_id: "15"
-          extra_text:  |
-          *Done Issues Tagged Against Tests:*
-          somelinkgoesheresomeotherlinkgoeshere
-          somethirdlink goes here"
+          extra_text:  ${{ steps.testing.outputs.text }}

--- a/.github/workflows/qaa_slack_bot.yml
+++ b/.github/workflows/qaa_slack_bot.yml
@@ -7,6 +7,8 @@ env:
 jobs: 
   post-to-slack:
     runs-on: ubuntu-latest
+    outputs: 
+      tags: ${{steps.testing.outputs.text}}
     steps: 
       - name: Dump Github context
         env: 
@@ -17,6 +19,11 @@ jobs:
         uses: actions/setup-node@v1
         with: 
           node-version: '12.x'
+      - name: Testing variable
+        id: testing 
+        run: |
+          AUDIT=$(node ./src/test.js)
+          echo "::set-output name=text::$AUDIT"
       - name: Run script 
         uses: ./
         with: 
@@ -24,4 +31,4 @@ jobs:
           run_status: "passed"
           bluescape_url: "stg1.bluescape.com"
           testrail_project_id: "15"
-          extra_text: "*Done Issues Tagged Against Tests:*\\nsomelinkgoeshere\nsomeotherlinkgoeshere\\nsomethirdlink goes here"
+          extra_text:  ${{ steps.testing.outputs.text }}

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ const main = async () => {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `${extraMarkdownText}`
+        text: process.env.INPUT_EXTRA_TEXT
       }
     })
     slackMessage.blocks.push(divider)

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ const main = async () => {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: '$INPUT_EXTRA_TEXT'
+        text: `${extraMarkdownText}`
       }
     })
     slackMessage.blocks.push(divider)

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ const main = async () => {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: process.env.INPUT_EXTRA_TEXT
+        text: extraMarkdownText.replace(/\\n/g, '\n')
       }
     })
     slackMessage.blocks.push(divider)

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ const main = async () => {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: extraMarkdownText
+        text: extraMarkdownText.replaceAll('\\n', '\n')
       }
     })
     slackMessage.blocks.push(divider)

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ const main = async () => {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `${extraMarkdownText}`
+        text: '$INPUT_EXTRA_TEXT'
       }
     })
     slackMessage.blocks.push(divider)

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ const main = async () => {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: extraMarkdownText.replaceAll('\\n', '\n')
+        text: extraMarkdownText.replace(/\\n/g, '\n')
       }
     })
     slackMessage.blocks.push(divider)

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ const main = async () => {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: extraMarkdownText.replace(/\\n/g, '\n')
+        text: `${extraMarkdownText}`
       }
     })
     slackMessage.blocks.push(divider)

--- a/src/test.js
+++ b/src/test.js
@@ -1,0 +1,1 @@
+console.log("*List of all things*\\none\\ntwo\\nthree");

--- a/src/test.js
+++ b/src/test.js
@@ -1,1 +1,0 @@
-console.log("*List of all things*\\none\\ntwo\\nthree");


### PR DESCRIPTION
This PR updates the `extra-text` portion of the qaa-slack-bot to un-escape escaped newlines passed to it. 

i.e, 
Previous behavior: When passed in `*List of all things*\\none\\ntwo\\nthree`, it would output 
*List of all things*\\none\\ntwo\\nthree

New behavior: It will instead output
*List of all things*
one
two 
three