### PR TITLE
QAA-2419: Unable to get repo link and failing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,10 @@ const main = async () => {
       )
     )
   }
+  links.push(makeButtonBlock(
+    'Testing an undefined link',
+    _.get(context, 'abc')
+  ))
 
   const divider = { type: 'divider' }
   const slackMessage = {

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ const main = async () => {
       )
     )
   }
-  links.push(makeButtonBlock('Repository', ghRepoLink))
+  if (ghRepoLink) links.push(makeButtonBlock('Repository', ghRepoLink))
   if (parameters.testrailProjectId) {
     links.push(
       makeButtonBlock(
@@ -71,10 +71,6 @@ const main = async () => {
       )
     )
   }
-  links.push(makeButtonBlock(
-    'Testing an undefined link',
-    _.get(context, 'abc')
-  ))
 
   const divider = { type: 'divider' }
   const slackMessage = {

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const main = async () => {
   const ghRepoName = context.repo.repo
   const ghBranch =
     _.get(context, ['event', 'branch']) || _.get(context, ['ref'])
-  const ghRepoLink = context.payload.event.repository.html_url || context.payload.repository.html_url 
+  const ghRepoLink = context.event.repository.html_url || context.payload.repository.html_url 
   const webhook = new IncomingWebhook(parameters.webhookUrl)
 
   const testText = [':tada: *Github Test Run Complete!* :tada:']

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const main = async () => {
   const ghRepoName = context.repo.repo
   const ghBranch =
     _.get(context, ['event', 'branch']) || _.get(context, ['ref'])
-  const ghRepoLink = context.payload.repository.html_url
+  const ghRepoLink = context.payload.event.repository.html_url || context.payload.repository.html_url 
   const webhook = new IncomingWebhook(parameters.webhookUrl)
 
   const testText = [':tada: *Github Test Run Complete!* :tada:']

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,10 @@ const main = async () => {
   const ghRepoName = context.repo.repo
   const ghBranch =
     _.get(context, ['event', 'branch']) || _.get(context, ['ref'])
-  const ghRepoLink = context.event.repository.html_url || context.payload.repository.html_url 
+  console.log("Context: ", context)
+  console.log("Context keys", Object.keys(context))
+  console.log("Event keys", Object.keys(context))
+  const ghRepoLink = context.event.repository.html_url || context.payload.repository.html_url
   const webhook = new IncomingWebhook(parameters.webhookUrl)
 
   const testText = [':tada: *Github Test Run Complete!* :tada:']

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const main = async () => {
   const ghBranch =
     _.get(context, ['event', 'branch']) || _.get(context, ['ref'])
   const ghRepoLink =
-    _.get(context, ['payload', 'repository', 'html_url']) || _.get(context, 'event', 'repository', 'html_url')
+    _.get(context, ['payload', 'repository', 'html_url']) || _.get(context, ['event', 'repository', 'html_url'])
   const webhook = new IncomingWebhook(parameters.webhookUrl)
 
   const testText = [':tada: *Github Test Run Complete!* :tada:']

--- a/src/index.js
+++ b/src/index.js
@@ -11,10 +11,8 @@ const main = async () => {
   const ghRepoName = context.repo.repo
   const ghBranch =
     _.get(context, ['event', 'branch']) || _.get(context, ['ref'])
-  console.log("Context: ", context)
-  console.log("Context keys", Object.keys(context))
-  console.log("Event keys", Object.keys(context))
-  const ghRepoLink = context.event.repository.html_url || context.payload.repository.html_url
+  const ghRepoLink =
+    _.get(context, ['payload', 'repository', 'html_url']) || _.get(context, 'event', 'repository', 'html_url')
   const webhook = new IncomingWebhook(parameters.webhookUrl)
 
   const testText = [':tada: *Github Test Run Complete!* :tada:']


### PR DESCRIPTION
This change now uses Lodash to get the repo link so that when it fails it does not crash. Nothing relies on the repo link so worst case we just get an empty link in the output. 

If the repo link is undefined, we don't get a link block for it. 