### PR TITLE
QAA-2471: Slack bot doesn't work with schedule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,15 +12,17 @@ const main = async () => {
   const ghBranch =
     _.get(context, ['event', 'branch']) || _.get(context, ['ref'])
   const ghRepoLink =
-    _.get(context, ['payload', 'repository', 'html_url']) || _.get(context, ['event', 'repository', 'html_url'])
+    _.get(context, ['payload', 'repository', 'html_url']) ||
+    _.get(context, ['event', 'repository', 'html_url']) ||
+    `${_.get(context, ['server_url'])}/${_.get(context, ['repository'])}`
   const webhook = new IncomingWebhook(parameters.webhookUrl)
 
   const testText = [':tada: *Github Test Run Complete!* :tada:']
   testText.push(makeTestLine('Repository', ghRepoName))
-  if (parameters.bluescapeUrl) testText.push(makeTestLine('Environment', parameters.bluescapeUrl))
+  if (parameters.bluescapeUrl) { testText.push(makeTestLine('Environment', parameters.bluescapeUrl)) }
   testText.push(makeTestLine('Branch', ghBranch))
-  if (parameters.ghPackage) testText.push(makeTestLine('Package', parameters.ghPackage))
-  if (parameters.runStatus) testText.push(makeTestLine('Status', parameters.runStatus))
+  if (parameters.ghPackage) { testText.push(makeTestLine('Package', parameters.ghPackage)) }
+  if (parameters.runStatus) { testText.push(makeTestLine('Status', parameters.runStatus)) }
 
   const links = []
   links.push(
@@ -142,11 +144,19 @@ function makeButtonBlock (title, link, style = undefined) {
   }
 }
 
-function grafanaLinkBuilder (base, startTime, endTime, environment, product, feature, process) {
+function grafanaLinkBuilder (
+  base,
+  startTime,
+  endTime,
+  environment,
+  product,
+  feature,
+  process
+) {
   const grafanaUrl = new URL(base)
   if (startTime) grafanaUrl.searchParams.append('from', startTime)
   if (endTime) grafanaUrl.searchParams.append('to', endTime)
-  if (environment) grafanaUrl.searchParams.append('var-Environment', environment)
+  if (environment) { grafanaUrl.searchParams.append('var-Environment', environment) }
   if (product) grafanaUrl.searchParams.append('var-Product', product)
   if (feature) grafanaUrl.searchParams.append('var-Feature', feature)
   if (process) grafanaUrl.searchParams.append('var-Process', process)


### PR DESCRIPTION
Slack bot wasn't working properly with scheduled runs. This is due to the fact that on scheduled runs, the Github context is different from during a repo dispatch. This causes the retrieved repo link to be undefined, which Slack checks for and then returns an error 400 for.

This change is to add an additional clause to the or to build the link manually if the other options aren't available.